### PR TITLE
fix: correct unkown to unknown typo in log message (core/dsl.go)

### DIFF
--- a/core/dsl.go
+++ b/core/dsl.go
@@ -108,7 +108,7 @@ func (dsl *Dsl) ConvertToDecisionFlow() (*DecisionFlow, error) {
 			newNode.SetElem(scorecardMap[newNode.NodeName])
 			flow.AddNode(&newNode)
 		default:
-			log.Warnf("dsl %s - %s convert warning: unkown node type %s", dsl.Key, dsl.Version, newNode.NodeKind)
+			log.Warnf("dsl %s - %s convert warning: unknown node type %s", dsl.Key, dsl.Version, newNode.NodeKind)
 		}
 	}
 	return flow, nil


### PR DESCRIPTION
Correct `unkown` → `unknown` typo in log.Warnf message in core/dsl.go.

1 file, 1 line fix.

---
GitHub: jydu_seven@outlook.com