### PR TITLE
fix: correct unkown to unknown typo in log warning

### DIFF
--- a/core/dsl.go
+++ b/core/dsl.go
@@ -108,7 +108,7 @@ func (dsl *Dsl) ConvertToDecisionFlow() (*DecisionFlow, error) {
 			newNode.SetElem(scorecardMap[newNode.NodeName])
 			flow.AddNode(&newNode)
 		default:
-			log.Warnf("dsl %s - %s convert warning: unkown node type %s", dsl.Key, dsl.Version, newNode.NodeKind)
+			log.Warnf("dsl %s - %s convert warning: unknown node type %s", dsl.Key, dsl.Version, newNode.NodeKind)
 		}
 	}
 	return flow, nil


### PR DESCRIPTION
## Summary
Corrects the typo `unkown` → `unknown` in log warning message at `core/dsl.go` line 111.

## Changes
- Fix typo in warning log message for unknown node type

## Testing
- Build verified with go build